### PR TITLE
Improve repo size calculation

### DIFF
--- a/seafile/FileSizeFormatter.m
+++ b/seafile/FileSizeFormatter.m
@@ -16,6 +16,14 @@ static int sMaxUnits = sizeof sUnits - 1;
 @implementation FileSizeFormatter
 static FileSizeFormatter *sharedLoader = nil;
 
+- (id)init
+{
+    if (self = [super init]) {
+        [self setNumberStyle:NSNumberFormatterDecimalStyle];
+        [self setMaximumFractionDigits:1];
+    }
+    return self;
+}
 
 - (NSString *)stringFromNumber:(NSNumber *)number useBaseTen:(BOOL)useBaseTen
 {

--- a/seafile/SeafFileViewController.m
+++ b/seafile/SeafFileViewController.m
@@ -346,7 +346,7 @@ enum {
 - (SeafCell *)getSeafRepoCell:(SeafRepo *)srepo forTableView:(UITableView *)tableView
 {
     SeafCell *cell = [self getCell:@"SeafCell" forTableView:tableView];
-    NSString *detail = [NSString stringWithFormat:@"%@, %@", [FileSizeFormatter stringFromNumber:[NSNumber numberWithInt:srepo.size ] useBaseTen:NO], [SeafDateFormatter stringFromInt:srepo.mtime]];
+    NSString *detail = [NSString stringWithFormat:@"%@, %@", [FileSizeFormatter stringFromNumber:[NSNumber numberWithUnsignedLongLong:srepo.size ] useBaseTen:NO], [SeafDateFormatter stringFromInt:srepo.mtime]];
     cell.detailTextLabel.text = detail;
     cell.imageView.image = srepo.image;
     cell.textLabel.text = srepo.name;

--- a/seafile/SeafRepos.h
+++ b/seafile/SeafRepos.h
@@ -14,7 +14,7 @@
 @property (readonly, copy) NSString *owner;
 @property (readonly) BOOL passwordRequired;
 @property (readonly) BOOL editable;
-@property (readonly) int size;
+@property (readonly) unsigned long long size;
 @property (readonly) int mtime;
 @end
 

--- a/seafile/SeafRepos.m
+++ b/seafile/SeafRepos.m
@@ -35,7 +35,7 @@
                    owner:(NSString *)aOwner
                 repoType:(NSString *)aRepoType
                     perm:(NSString *)aPerm
-                    size:(int)aSize
+                    size:(unsigned long long)aSize
                    mtime:(int)aMtime
                encrypted:(BOOL)aEncrypted
 {


### PR DESCRIPTION
I have libraries of more than 2GB that were displayed with a negative size.

This PR fixes this and also adds the first digit to the formatted file size (as in Seahub).
