### PR TITLE
SeafileCell: fix aspect ratio of preview image

### DIFF
--- a/seafile/en.lproj/SeafCell.xib
+++ b/seafile/en.lproj/SeafCell.xib
@@ -20,7 +20,7 @@
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="highlightedColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </label>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4">
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="4">
                         <rect key="frame" x="8" y="8" width="32" height="32"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="32" id="5pS-w2-Rm7"/>


### PR DESCRIPTION
A tiny fix to make preview images to appear in the correct aspect ratio.

See screenshots for the difference:

Broken:
![broken](https://cloud.githubusercontent.com/assets/339350/14046475/14293f2a-f2a2-11e5-853d-50b76262a438.png)

Fixed:
![fixed](https://cloud.githubusercontent.com/assets/339350/14046476/1429e100-f2a2-11e5-95b3-3cd0dd2bce83.png)

