### PR TITLE
delete Django Session Cookie when user is not logged in anymore

### DIFF
--- a/seafile/StartViewController.m
+++ b/seafile/StartViewController.m
@@ -413,6 +413,14 @@
     if (!conn) return NO;
     if (![conn authorized]) {
         NSString *title = NSLocalizedString(@"The token is invalid, you need to login again", @"Seafile");
+        if (conn.isShibboleth) {
+            NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+            for (NSHTTPCookie *each in cookieStorage.cookies) {
+                if([each.name isEqualToString:@"sessionid"]) {
+                    [cookieStorage deleteCookie:each];
+                }
+            }
+        }
         [self alertWithTitle:title handler:^{
             int type = conn.isShibboleth ? ACCOUNT_SHIBBOLETH : ACCOUNT_OTHER;
             [self showAccountView:conn type:type];


### PR DESCRIPTION
If the auth token gets deleted on the server site - the iOS client is stuck in an endless loop, which prevents the user from logging back in - deleting the session cookie fixes this bug