### PR TITLE
Feature to change preview font size for plain/text files.

### DIFF
--- a/seafile/QuickSettingsPanel.h
+++ b/seafile/QuickSettingsPanel.h
@@ -1,0 +1,17 @@
+//
+//  SettingsBlock.h
+//  SettingsAnimation
+//
+//  Created by Max on 30/09/2017.
+//  Copyright © 2017 34x. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+FOUNDATION_EXPORT NSString* const QuickSettingsFontSizeIncrement;
+FOUNDATION_EXPORT NSString* const QuickSettingsFontSizeDecrement;
+
+@interface QuickSettingsPanel : UIView
+@property(nonatomic, copy) void(^actionHandler)(NSString* actionKey, NSDictionary* userInfo);
+- (void)setOpen:(BOOL)isOpen animate:(BOOL)animate;
+@end

--- a/seafile/QuickSettingsPanel.m
+++ b/seafile/QuickSettingsPanel.m
@@ -1,0 +1,214 @@
+//
+//  SettingsBlock.m
+//  SettingsAnimation
+//
+//  Created by Max on 30/09/2017.
+//  Copyright © 2017 34x. All rights reserved.
+//
+
+#import "QuickSettingsPanel.h"
+
+NSString* const QuickSettingsFontSizeIncrement = @"QuickSettingsFontSizeIncrement";
+NSString* const QuickSettingsFontSizeDecrement = @"QuickSettingsFontSizeDecrement";;
+
+@interface QuickSettingsPanel()
+@property (nonatomic) UIView* settingsBlock;
+@property (nonatomic) UIButton* settingsToggle;
+@property (nonatomic) CGSize elementSize;
+@property (nonatomic) CGSize panelSize;
+@property (nonatomic) UIButton* fontSizeIncrementButton;
+@property (nonatomic) UIButton* fontSizeDecrementButton;
+@property (nonatomic, readonly) BOOL isOpen;
+@end
+
+@implementation QuickSettingsPanel
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self configureView];
+    }
+    return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self configureView];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    // Moving settings overlay to the right bottom corner
+    CGSize parentSize = self.superview.bounds.size;
+    CGFloat margin = self.elementSize.width * 0.25;
+    self.frame = CGRectMake(parentSize.width - self.panelSize.width - margin,
+                            parentSize.height - self.panelSize.height - margin,
+                            self.panelSize.width, self.panelSize.height);
+    
+    self.settingsBlock.center = CGPointMake(self.bounds.size.width, self.bounds.size.height);
+}
+
+- (void)orientationChanged:(NSNotification*)notification {
+    [self layoutSubviews];
+}
+
+- (void)configureView {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
+    
+    self.elementSize = CGSizeMake(52.0, 52.0);
+    self.panelSize = CGSizeMake(self.elementSize.width * 3, self.elementSize.height);
+
+    UIView* settingsBlock = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.panelSize.width, self.panelSize.height)];
+    settingsBlock.layer.anchorPoint = CGPointMake(1.0, 1.0);
+    
+    
+    settingsBlock.backgroundColor = [[UIColor orangeColor] colorWithAlphaComponent:0.9];
+    settingsBlock.layer.cornerRadius = self.elementSize.height / 8.0;
+    
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(toggle:)];
+    [settingsBlock addGestureRecognizer:tap];
+    
+    self.settingsBlock = settingsBlock;
+    
+    CGFloat x = settingsBlock.bounds.size.width;
+    
+    UIButton *settings = [[UIButton alloc] initWithFrame:CGRectMake(0.0, 0, self.elementSize.width, self.elementSize.height)];
+    [settings setTitle:@"→" forState:UIControlStateNormal];
+    settings.titleLabel.font = [UIFont systemFontOfSize: self.elementSize.height * 0.8];
+    [settings addTarget:self action:@selector(toggle:) forControlEvents:UIControlEventTouchUpInside];
+    settings.alpha = 0.8;
+    self.settingsToggle = settings;
+    [self.settingsBlock addSubview:settings];
+    
+    UIView *separator = [[UIView alloc] initWithFrame:CGRectMake(self.elementSize.width, 0, 2.0, self.elementSize.height)];
+    separator.backgroundColor = [[UIColor whiteColor]colorWithAlphaComponent:0.4];
+    [self.settingsBlock addSubview:separator];
+    
+    x = x - self.elementSize.width;
+    
+    self.fontSizeIncrementButton = [[UIButton alloc] initWithFrame:CGRectMake(x, 0, self.elementSize.width, self.elementSize.height)];
+    
+    [self.fontSizeIncrementButton setTitle:@"A" forState:UIControlStateNormal];
+    self.fontSizeIncrementButton.titleLabel.font = [UIFont systemFontOfSize: self.elementSize.height * 0.8];
+    [self.fontSizeIncrementButton addTarget:self action:@selector(settingsDidChange:) forControlEvents:UIControlEventTouchUpInside];
+    [self.settingsBlock addSubview:self.fontSizeIncrementButton];
+    
+    x = x - self.elementSize.width;
+    
+    self.fontSizeDecrementButton = [[UIButton alloc] initWithFrame:CGRectMake(x, 0, self.elementSize.width, self.elementSize.height)];
+    [self.fontSizeDecrementButton setTitle:@"A" forState:UIControlStateNormal];
+    self.fontSizeDecrementButton.titleLabel.font = [UIFont systemFontOfSize:self.elementSize.height / 2.0];
+    [self.fontSizeDecrementButton addTarget:self action:@selector(settingsDidChange:) forControlEvents:UIControlEventTouchUpInside];
+    [self.settingsBlock addSubview:self.fontSizeDecrementButton];
+    
+    [self addSubview:settingsBlock];
+    
+    [self toggleAnimate:NO];
+}
+
+- (void)settingsDidChange:(id)element {
+    NSString* key;
+    
+    if (element == self.fontSizeIncrementButton) {
+        key = QuickSettingsFontSizeIncrement;
+    } else if (element == self.fontSizeDecrementButton) {
+        key = QuickSettingsFontSizeDecrement;
+    }
+    
+    if (key && self.actionHandler) {
+        self.actionHandler(key, nil);
+    }
+}
+
+- (void)toggle:(id)button {
+    [self toggleAnimate:YES];
+}
+
+- (void)toggleAnimate:(BOOL)animate {
+    CGFloat targetWidth = 0;
+    CGFloat rotateFrom = 0.0;
+    CGFloat rotateTo = 0.0;
+    CGFloat scaleFrom = 1.0;
+    CGFloat scaleTo = 0.0;
+    CGFloat alphaFrom = 0.0;
+    CGFloat alphaTo = 0.0;
+    
+    // going to close
+    if (self.isOpen) {
+        targetWidth = self.elementSize.width;
+        rotateFrom = 0;
+        rotateTo = M_PI;
+        scaleTo = 0.5;
+        alphaFrom = 1.0;
+        alphaTo = 0.4;
+    // going to open
+    } else {
+        targetWidth = self.panelSize.width;
+        rotateFrom = M_PI;
+        rotateTo = 0;
+        scaleTo = 1.0;
+        scaleFrom = 0.5;
+        alphaFrom = 0.4;
+        alphaTo = 1.0;
+    }
+    
+    CGRect bounds = self.settingsBlock.bounds;
+    NSTimeInterval commonDuration = 0.4;
+    
+    CABasicAnimation* toggleRotate = [CABasicAnimation animationWithKeyPath:@"transform.rotation.z"];
+    toggleRotate.fromValue = @(rotateFrom);
+    toggleRotate.toValue = @(rotateTo);
+    toggleRotate.fillMode = kCAFillModeBackwards;
+    toggleRotate.duration = commonDuration;
+    CGAffineTransform zero = CGAffineTransformMakeRotation(0);
+    
+    self.settingsToggle.transform = CGAffineTransformRotate(zero, rotateTo);
+    
+    CABasicAnimation* commonWidth = [CABasicAnimation animationWithKeyPath:@"bounds.size.width"];
+    commonWidth.fromValue = @(bounds.size.width);
+    commonWidth.toValue = @(targetWidth);
+    commonWidth.duration = commonDuration;
+    
+    CABasicAnimation* commonScale = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
+    commonScale.fromValue = @(scaleFrom);
+    commonScale.toValue = @(scaleTo);
+    commonScale.duration = commonDuration;
+    commonScale.fillMode = kCAFillModeBackwards;
+    
+    CABasicAnimation* commonAlpha = [CABasicAnimation animationWithKeyPath:@"opacity"];
+    commonAlpha.fromValue = @(alphaFrom);
+    commonAlpha.toValue = @(alphaTo);
+    commonAlpha.duration = commonDuration;
+    
+    if (animate) {
+        [self.settingsToggle.layer addAnimation:toggleRotate forKey:nil];
+        [self.settingsBlock.layer addAnimation:commonWidth forKey:nil];
+        [self.settingsBlock.layer addAnimation:commonScale forKey:nil];
+        [self.settingsBlock.layer addAnimation:commonAlpha forKey:nil];
+    }
+    
+    self.settingsBlock.bounds = CGRectMake(0, 0, targetWidth, bounds.size.height);
+    CGAffineTransform zeroScale = CGAffineTransformMakeScale(1.0, 1.0);
+    self.settingsBlock.transform = CGAffineTransformScale(zeroScale, scaleTo, scaleTo);
+    self.settingsBlock.alpha = alphaTo;
+}
+
+- (BOOL)isOpen {
+    return self.settingsBlock.bounds.size.width > self.elementSize.width;
+}
+
+- (void)setOpen:(BOOL)isOpen animate:(BOOL)animate {
+    // if it's already the same do nothing
+    if (self.isOpen == isOpen) {
+        return;
+    }
+    
+    [self toggleAnimate:animate];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+@end

--- a/seafile/SeafDetailViewController.m
+++ b/seafile/SeafDetailViewController.m
@@ -392,6 +392,8 @@ NSString* const DetailPreviewFontSizeKey = @"DetailPreviewFontSizeKey";
 {
     [self updateNavigation];
     [super viewWillAppear:animated];
+    
+    [[self getUserDefaults] addObserver:self forKeyPath:DetailPreviewFontSizeKey options:NSKeyValueObservingOptionNew context:nil];
 }
 
 #pragma mark - Split view
@@ -419,6 +421,8 @@ NSString* const DetailPreviewFontSizeKey = @"DetailPreviewFontSizeKey";
     if (self.masterPopoverController != nil) {
         [self.masterPopoverController dismissPopoverAnimated:YES];
     }
+    
+    [[self getUserDefaults] removeObserver:self forKeyPath:DetailPreviewFontSizeKey context:nil];
     [super viewWillDisappear:animated];
 }
 

--- a/seafile/SeafDetailViewController.m
+++ b/seafile/SeafDetailViewController.m
@@ -169,6 +169,7 @@ NSString* const DetailPreviewFontSizeKey = @"DetailPreviewFontSizeKey";
     if (!self.isViewLoaded) return;
 
     [self updateNavigation];
+    [self.quickSettingsPanel setHidden:YES];
     CGRect r = CGRectMake(self.view.frame.origin.x, 64, self.view.frame.size.width, self.view.frame.size.height - 64);
     switch (self.state) {
         case PREVIEW_DOWNLOADING:
@@ -214,6 +215,14 @@ NSString* const DetailPreviewFontSizeKey = @"DetailPreviewFontSizeKey";
             self.webView.frame = r;
             [self.webView loadRequest:request];
             self.webView.hidden = NO;
+            if ([self canApplyPreviewFontSize]) {
+                [self.quickSettingsPanel setHidden:NO];
+                [self.quickSettingsPanel setOpen:NO animate:NO];
+                __weak id weakSelf = self;
+                self.quickSettingsPanel.actionHandler = ^(NSString *actionKey, NSDictionary *userInfo) {
+                    [weakSelf changePreviewFontSize:actionKey];
+                };
+            }
             break;
         }
         case PREVIEW_PHOTO:
@@ -329,6 +338,10 @@ NSString* const DetailPreviewFontSizeKey = @"DetailPreviewFontSizeKey";
     self.view.autoresizesSubviews = YES;
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     self.navigationController.navigationBar.tintColor = BAR_COLOR;
+    self.quickSettingsPanel = [QuickSettingsPanel new];
+    [self.view addSubview:self.quickSettingsPanel];
+    [self registerDefaultPreviewFontSize];
+    
     [self refreshView];
 }
 

--- a/seafile/SeafDetailViewController.m
+++ b/seafile/SeafDetailViewController.m
@@ -208,10 +208,9 @@ NSString* const DetailPreviewFontSizeKey = @"DetailPreviewFontSizeKey";
         case PREVIEW_WEBVIEW: {
             Debug("Preview by webview %@\n", self.preViewItem.previewItemTitle);
             NSURLRequest *request = [[NSURLRequest alloc] initWithURL:self.preViewItem.previewItemURL cachePolicy: NSURLRequestUseProtocolCachePolicy timeoutInterval: 1];
-            if (self.state == PREVIEW_WEBVIEW_JS)
-                self.webView.delegate = self;
-            else
-                self.webView.delegate = nil;
+            
+            self.webView.delegate = self;
+            
             self.webView.frame = r;
             [self.webView loadRequest:request];
             self.webView.hidden = NO;
@@ -739,9 +738,13 @@ NSString* const DetailPreviewFontSizeKey = @"DetailPreviewFontSizeKey";
 # pragma - UIWebViewDelegate
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {
-    if (self.preViewItem) {
-        NSString *js = [NSString stringWithFormat:@"setContent(\"%@\");", [self.preViewItem.strContent stringEscapedForJavasacript]];
-        [self.webView stringByEvaluatingJavaScriptFromString:js];
+    if (self.state == PREVIEW_WEBVIEW_JS) {
+        if (self.preViewItem) {
+            NSString *js = [NSString stringWithFormat:@"setContent(\"%@\");", [self.preViewItem.strContent stringEscapedForJavasacript]];
+            [self.webView stringByEvaluatingJavaScriptFromString:js];
+        }
+    } else {
+        [self applyPreviewFontSize];
     }
 }
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType

--- a/seafilePro.xcodeproj/project.pbxproj
+++ b/seafilePro.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		10CC62C9699DE05CBA3647E4 /* libPods-seafile-appstore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E2A39A0EBB6C3379F30D1A83 /* libPods-seafile-appstore.a */; };
 		11FAE5D19696AF534A19C252 /* libPods-SeafProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 08E34A4BEBB32AD5D2CB9442 /* libPods-SeafProvider.a */; };
+		50098B991F802E8A0072941D /* QuickSettingsPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 50098B971F802E8A0072941D /* QuickSettingsPanel.m */; };
 		5704C6D31753A1380028F4FE /* IntelligentSplitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5704C6D11753A1380028F4FE /* IntelligentSplitViewController.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		5704C6F91756710F0028F4FE /* tab-account.png in Resources */ = {isa = PBXBuildFile; fileRef = 5704C6F51756710F0028F4FE /* tab-account.png */; };
 		5704C6FB1756710F0028F4FE /* tab-modify.png in Resources */ = {isa = PBXBuildFile; fileRef = 5704C6F61756710F0028F4FE /* tab-modify.png */; };
@@ -256,6 +257,8 @@
 		159E0D2A7419F67E532A240F /* libPods-SeafAction.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SeafAction.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2979DE872836DD67FEA29262 /* Pods-SeafProviderFileProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SeafProviderFileProvider.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SeafProviderFileProvider/Pods-SeafProviderFileProvider.debug.xcconfig"; sourceTree = "<group>"; };
 		3DFD7A698B44546A8DDD2D26 /* libPods-SeafProviderFileProvider.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SeafProviderFileProvider.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		50098B971F802E8A0072941D /* QuickSettingsPanel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QuickSettingsPanel.m; sourceTree = "<group>"; };
+		50098B981F802E8A0072941D /* QuickSettingsPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuickSettingsPanel.h; sourceTree = "<group>"; };
 		5704C6D01753A1380028F4FE /* IntelligentSplitViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntelligentSplitViewController.h; sourceTree = "<group>"; };
 		5704C6D11753A1380028F4FE /* IntelligentSplitViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntelligentSplitViewController.m; sourceTree = "<group>"; };
 		5704C6F51756710F0028F4FE /* tab-account.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "tab-account.png"; sourceTree = "<group>"; };
@@ -555,6 +558,8 @@
 		5704C6CF1753A07E0028F4FE /* thirdpart */ = {
 			isa = PBXGroup;
 			children = (
+				50098B981F802E8A0072941D /* QuickSettingsPanel.h */,
+				50098B971F802E8A0072941D /* QuickSettingsPanel.m */,
 				5704C6D01753A1380028F4FE /* IntelligentSplitViewController.h */,
 				5704C6D11753A1380028F4FE /* IntelligentSplitViewController.m */,
 			);
@@ -1444,6 +1449,7 @@
 				5704C6D31753A1380028F4FE /* IntelligentSplitViewController.m in Sources */,
 				57F476EC1C00623300047395 /* SeafPhotoThumb.m in Sources */,
 				576C91C4177EB43F007B50BD /* SeafDirViewController.m in Sources */,
+				50098B991F802E8A0072941D /* QuickSettingsPanel.m in Sources */,
 				58D40A7E1E9AF86D00A68BEF /* SeafData.m in Sources */,
 				58D40A691E9AF72200A68BEF /* SeafGlobal.m in Sources */,
 			);


### PR DESCRIPTION
Hi! 
First of all thank you for the app and server!

In short what this pr doing:

<img src="https://user-images.githubusercontent.com/60165/31864538-cadf31c0-b75e-11e7-9d81-f8b7cdf71584.gif" width="200" />

And details:

One of my way to use Seafile on iOS it's reading and editing text files. I am using iPhone SE and standard WebView font size sometimes very difficult to read so I decided to contribute a bit to the project.

This PR contains from 2 major parts:
1. View element that display quick settings for changing font size (it's small orange box on the right bottom corner with the arrow). I decided to create this instead of putting this to common settings for two reasons: the first one - I found it's not easy to understand philosophy of settings screen at all and the second is that's much more intuitive to change font size right in context of viewing a file.

2. The second part is about actually changing the font and storing it between app launches. For storing data I used `[NSUserDefaults standardUserDefaults]` but not sure if it's correct or not, because in some places app uses defaults for domain and in some - standard.

For handling changes I added observer for this property in user defaults.

And for actually setting font size I used js string `document.body.style.fontSize = '%@';` in the `webView`. Sizes are provided in `%` to reflect user defined settings for the system fonts and default value is `100%`.

Bugs: I found that with some sizes update did not work (for example when font size changed from 400% to 420% then to 440% e.t.c.) but after closing the view and opening it again it uses correct size. I am not sure why it happens, maybe some MobileSafari specific.

Best regards
Maks