### PR TITLE
Fix crash if groupName is parsed as NSNull

### DIFF
--- a/Pod/Classes/SeafRepos.m
+++ b/Pod/Classes/SeafRepos.m
@@ -48,6 +48,9 @@
     if (aEncrypted) {
         aMime = @"text/directory-documents-encrypted";
     }
+    if ([groupName isKindOfClass:[NSNull class]]) {
+        groupName = nil;
+    }
     if (self = [super initWithConnection:aConnection oid:anId repoId:aRepoId perm:aPerm name:aName path:@"/" mime:aMime]) {
         _desc = aDesc;
         _owner = aOwner;


### PR DESCRIPTION
The app started to crash when I added an account from our local Seafile server. After some debugging I found out that for some libraries the "group_name" is parsed as NSNull by the JSON parser which isn't expected by the code. This fixes the issue for me.