### PR TITLE
Optimize thumbnail display performance.

### DIFF
--- a/Pod/Classes/SeafDataTaskManager.h
+++ b/Pod/Classes/SeafDataTaskManager.h
@@ -115,6 +115,13 @@ typedef void(^DownLoadFinshBlock)(id<SeafTask>  _Nonnull task);
  */
 - (SeafAccountTaskQueue * _Nonnull)accountQueueForConnection:(SeafConnection * _Nonnull)connection;
 
+
+/**
+ * Remove an account thumb from accountQueue
+ * @param thumb The account thumb
+ */
+- (void)removeThumbTaskFromAccountQueue:(SeafThumb * _Nonnull)thumb;
+
 @end
 
 @interface SeafAccountTaskQueue : NSObject

--- a/Pod/Classes/SeafDataTaskManager.m
+++ b/Pod/Classes/SeafDataTaskManager.m
@@ -181,6 +181,12 @@
     [accountQueue addThumbTask:thumb];
 }
 
+- (void)removeThumbTaskFromAccountQueue:(SeafThumb * _Nonnull)thumb
+{
+    SeafAccountTaskQueue *accountQueue = [self getAccountQueueWithIndentifier:thumb.accountIdentifier];
+    [accountQueue removeThumbTask:thumb];
+}
+
 /**
  * Retrieves an account task queue associated with a specific identifier.
  * @param identifier The identifier associated with the account.

--- a/Pod/Classes/SeafFile.h
+++ b/Pod/Classes/SeafFile.h
@@ -76,6 +76,7 @@ typedef void (^SeafThumbCompleteBlock)(BOOL ret);
 @property (nonatomic, readonly, getter=isUploading) BOOL uploading;///< Whether the file is currently uploading.
 @property (copy, nonatomic) NSString * _Nullable thumbnailURLStr;//image thumbnail Url String
 @property (nonatomic, assign) NSInteger thumbFailedCount;//download thumb failure count
+@property (nonatomic, copy) NSURLSessionDownloadTask * _Nullable thumbtask;
 
 /**
  * Checks if the file is currently being downloaded.
@@ -140,6 +141,11 @@ typedef void (^SeafThumbCompleteBlock)(BOOL ret);
  * Cancels any ongoing thumbnail download.
  */
 - (void)cancelThumb;
+
+/**
+ * Cancels the thumb which not download complete.
+ */
+- (void)cancelNotDisplayThumb;
 
 /**
  * Uploads the file from a specified URL.

--- a/Pod/Classes/SeafTaskQueue.h
+++ b/Pod/Classes/SeafTaskQueue.h
@@ -19,6 +19,11 @@
 #define DEFAULT_RETRYCOUNT 3
 
 /**
+ * Default number of times a FileThumb should retry on failure.
+ */
+#define Default_FileThumb_RetryCount 3
+
+/**
  * Default interval in seconds between retries of a task.
  */
 #define DEFAULT_ATTEMPT_INTERVAL 60 // 1 min

--- a/Pod/Classes/SeafTaskQueue.m
+++ b/Pod/Classes/SeafTaskQueue.m
@@ -65,8 +65,9 @@
             [strongSelf tick];
         };
         self.innerQueueTaskProgressBlock = ^(id<SeafTask> task, float progress) {
-            if (weakSelf.taskProgressBlock) {
-                weakSelf.taskProgressBlock(task, progress);
+            __strong __typeof(self) strongSelf = weakSelf;
+            if (strongSelf.taskProgressBlock) {
+                strongSelf.taskProgressBlock(task, progress);
             }
         };
     }
@@ -143,6 +144,7 @@
     task.retryable = false;
     @synchronized (self.tasks) {
         if ([self.tasks containsObject:task]) {
+//            Debug(@"Delete task ,remain undeleted %lu", (unsigned long)self.tasks.count);
             return [self.tasks removeObject:task];
         }
         @synchronized (self.ongoingTasks) {

--- a/Pod/Classes/SeafUploadFile.h
+++ b/Pod/Classes/SeafUploadFile.h
@@ -49,7 +49,7 @@ typedef void (^SeafUploadCompletionBlock)(SeafUploadFile *file, NSString *oid, N
 
 @property (readonly) float uProgress;/// Current upload progress as a float between 0 and 1.
 
-@property (nonatomic) id<SeafUploadDelegate> delegate;/// Delegate to handle progress and completion updates.
+@property (nonatomic, weak) id<SeafUploadDelegate> delegate;/// Delegate to handle progress and completion updates.
 
 @property (nonatomic) SeafUploadCompletionBlock completionBlock;
 
@@ -85,4 +85,9 @@ typedef void (^SeafUploadCompletionBlock)(SeafUploadFile *file, NSString *oid, N
  * Cleans up resources associated with the file once it has been uploaded.
  */
 - (void)cleanup;
+
+/**
+ * Asynchronously get photo library images.
+ */
+- (void)iconWithCompletion:(void (^)(UIImage *image))completion;
 @end

--- a/Pod/Classes/Utils.h
+++ b/Pod/Classes/Utils.h
@@ -98,6 +98,9 @@
 /// Load an image from a path, optionally using a cache.
 + (UIImage *)imageFromPath:(NSString *)path withMaxSize:(float)length cachePath:(NSString *)cachePath;
 
+/// Load an image asynchronously.
++ (void)imageFromPath:(NSString *)path withMaxSize:(float)length cachePath:(NSString *)cachePath completion:(void (^)(UIImage *image))completion;
+
 /// Convert a query string to a dictionary of parameters.
 + (NSDictionary *)queryToDict:(NSString *)query;
 
@@ -135,5 +138,8 @@
 + (NSString *)getNewOidFromMtime:(long long)mtime
                           repoId:(NSString *)repoId
                             path:(NSString *)path;
+
+//cell detailText color
++ (UIColor *)cellDetailTextTextColor;
 
 @end

--- a/seafile/SeafCell.h
+++ b/seafile/SeafCell.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import "SWTableViewCell.h"
+#import "SeafFile.h"
 
 typedef void(^MoreButtonTouchBlock)(NSIndexPath *indexPath);
 
@@ -28,6 +29,11 @@ typedef void(^MoreButtonTouchBlock)(NSIndexPath *indexPath);
 @property (strong, nonatomic) NSIndexPath *cellIndexPath;
 
 @property (nonatomic, copy) MoreButtonTouchBlock moreButtonBlock;
+@property (nonatomic, copy) NSString *imageLoadIdentifier;//Cell identifier is used for asynchronous image loading
+@property (nonatomic, strong) SeafFile *cellSeafFile;
+
 - (void)reset;
+
+- (void)resetCellFile;
 
 @end

--- a/seafile/SeafCell.m
+++ b/seafile/SeafCell.m
@@ -34,12 +34,20 @@
 - (void)reset
 {
     self.detailTextLabel.text = nil;
-    self.detailTextLabel.textColor = [UIColor colorWithRed:0.666667 green:0.666667 blue:0.666667 alpha:1];
+    self.detailTextLabel.textColor = Utils.cellDetailTextTextColor;
     self.badgeImage.hidden = true;
     self.badgeLabel.hidden = true;
     self.cacheStatusView.hidden = true;
     self.progressView.hidden = true;
-    self.imageView.image = nil;
+    [self resetCellFile];
+}
+
+//cancel thumb task,clear cell seafile,clear cache thumb image in memory
+- (void)resetCellFile {
+    if (self.cellSeafFile){
+        [self.cellSeafFile cancelNotDisplayThumb];
+        self.cellSeafFile = nil;
+    }
 }
 
 - (IBAction)moreButtonTouch:(id)sender {

--- a/seafile/SeafDetailViewController.h
+++ b/seafile/SeafDetailViewController.h
@@ -25,7 +25,7 @@ enum PREVIEW_STATE {
 @property (readonly) int state;
 
 @property (nonatomic) id<SeafPreView> preViewItem;
-@property (nonatomic) UIViewController<SeafDentryDelegate> *masterVc;
+@property (nonatomic, weak) UIViewController<SeafDentryDelegate> *masterVc;
 @property (nonatomic, strong) QLPreviewController *qlViewController;
 
 

--- a/seafile/SeafDetailViewController.m
+++ b/seafile/SeafDetailViewController.m
@@ -356,6 +356,12 @@ enum SHARE_STATUS {
     [super didReceiveMemoryWarning];
 }
 
+- (void)dealloc {
+    [self.webView stopLoading];
+    self.webView.navigationDelegate = nil;
+    [self.webView removeFromSuperview];
+}
+
 - (void)viewWillLayoutSubviews
 {
     [super viewWillLayoutSubviews];

--- a/seafile/SeafStarredFilesViewController.m
+++ b/seafile/SeafStarredFilesViewController.m
@@ -337,7 +337,7 @@
         textColor = UIColor.redColor;
     } else {
         detailText = sfile.starredDetailText;
-        textColor = [UIColor colorWithRed:0.666667 green:0.666667 blue:0.666667 alpha:1];
+        textColor = Utils.cellDetailTextTextColor;
     }
     [self updateCellUI:cell cellName:sfile.name detailText:detailText detailTextColor:textColor image:sfile.icon morButtonIsHidden:NO];
     
@@ -356,7 +356,7 @@
         textColor = UIColor.redColor;
     } else {
         detailText = sDir.detailText;
-        textColor = [UIColor colorWithRed:0.666667 green:0.666667 blue:0.666667 alpha:1];
+        textColor = Utils.cellDetailTextTextColor;
     }
     
     [self updateCellUI:cell cellName:sDir.name detailText:detailText detailTextColor:textColor image:sDir.icon morButtonIsHidden:NO];


### PR DESCRIPTION
1.Modify to cancel unfinished thumbnail requests when a cell slides out of the page.
2.If a cell slides out of the page, clear the thumbnail cache in memory.
3.Fix the bug where, if thumbnail download fails and a detailed image is available, it continuously and endlessly requests the thumbnail.