### PR TITLE
Do not download large files by blocks

### DIFF
--- a/Pod/Classes/SeafDownloadOperation.m
+++ b/Pod/Classes/SeafDownloadOperation.m
@@ -69,7 +69,7 @@
     SeafConnection *connection = self.file.connection;
     self.file.state = SEAF_DENTRY_LOADING;
 
-    if ([connection shouldLocalDecrypt:self.file.repoId] || self.file.filesize > LARGE_FILE_SIZE) {
+    if ([connection shouldLocalDecrypt:self.file.repoId]) {
         Debug("Download file %@ by blocks: %lld", self.file.name, self.file.filesize);
         [self downloadByBlocks:connection];
     } else {


### PR DESCRIPTION
Files > 10 MB are getting downloaded in blocks which leads to corrupted files when downloading files from encrypted libraries since the encrypted blocks are no longer local decrypted (#444).

This PR removes the block based download for large files similar to the android application.

Additionally the whole local decryption check (`shouldLocalDecrypt`, `localDecrypt`, `setLocalDecryptionEnabled`, ..) could also be removed.